### PR TITLE
ssh blogpost: update pubkey filename

### DIFF
--- a/_posts/2020-02-05-ssh.md
+++ b/_posts/2020-02-05-ssh.md
@@ -134,12 +134,12 @@ You can copy it in the *~/.ssh/authorized_keys* file of the remote server.
 ## To use this key with your usual SSH Agent and Git, etc
 Add the SSH Public key Identifier into a file.
 ```bash
-$ echo "<ssh://username@hostname|nist256p1>" > ~/.ssh/nanox-keys.conf
+$ echo "<ssh://username@hostname|nist256p1>" > ~/.ssh/nanox-keys.conf.pub
 ```
 And then run the ledger-agent to link it with the shell.
 
 ```bash
-$ ledger-agent ~/.ssh/nanox-keys.conf -s -v
+$ ledger-agent ~/.ssh/nanox-keys.conf.pub -s -v
 ```
 
 You can now connect to a remote server using ssh from your device.


### PR DESCRIPTION
The `.pub` extension allows the ssh agent to load pub keys without confirmation.
Related code: https://github.com/romanz/trezor-agent/blob/52d840cbbb5a097c16b7a09932ef78c17aa78f20/libagent/ssh/__init__.py#L265