### PR TITLE
put the new link for the developer portal

### DIFF
--- a/about.md
+++ b/about.md
@@ -14,5 +14,5 @@ Have a look at our [GitHub](https://github.com/ledgerhq).
 
 Pull requests are welcome :)
 
-If you're a developper and would like to write app on Nano S or Nano X, have a look to the [Documentation](https://ledger.readthedocs.io/en/latest/).
+If you're a developper and would like to write app on Nano S or Nano X, have a look to the [Documentation](https://developers.ledger.com/).
 


### PR DESCRIPTION
All the doc is now on the [developer portal](https://developers.ledger.com/)